### PR TITLE
Fix mpegts error when no 'index' in data

### DIFF
--- a/mpegts
+++ b/mpegts
@@ -86,11 +86,12 @@ while True:
         if 'tag:service_name' in data:
             lastChannelName = data['tag:service_name'].lower()
             channels[lastChannelName] = data
-    elif nb_streams > 0:
-        nb_streams -= 1
-        channelStreams[lastChannelName].append(data['index'])
     elif 'index' in data:
-        streams[data['index']] = data
+        if nb_streams > 0:
+            nb_streams -= 1
+            channelStreams[lastChannelName].append(data['index'])
+        else:
+            streams[data['index']] = data
 
 proc.wait()
 if proc.returncode != 0:


### PR DESCRIPTION
Trying to run mpegts on a captured TS gave the following error:
```
Traceback (most recent call last):
  File "/home/g/Downloads/DVBdirect/./mpegts", line 91, in <module>
    channelStreams[lastChannelName].append(data['index'])
KeyError: 'index'
```

I added a check to see if 'index' was in fact in the data before doing stuff with it, and it now seems to work perfectly.

[Sample capture](https://github.com/lightful/DVBdirect/files/10609409/out.mts.zip), in a zip file (can't upload `.mts`)